### PR TITLE
Add get_level_by_name function to retrieve both built-in and custom levels

### DIFF
--- a/lua/lual/levels/init.lua
+++ b/lua/lual/levels/init.lua
@@ -209,4 +209,27 @@ function levels.get_custom_level(name)
     return nil, nil
 end
 
+-- Gets level information by name (from both built-in and custom levels)
+-- @param name string The level name
+-- @return string, number The level name (uppercase) and number, or nil if not found
+function levels.get_level_by_name(name)
+    if type(name) ~= "string" then
+        return nil, nil
+    end
+
+    -- First check built-in levels (case insensitive but return uppercase)
+    local upper_name = name:upper()
+    if levels.definition[upper_name] then
+        return upper_name, levels.definition[upper_name]
+    end
+
+    -- Then check custom levels
+    local level_no = _custom_levels[name:lower()]
+    if level_no then
+        return name:upper(), level_no
+    end
+
+    return nil, nil
+end
+
 return levels

--- a/lua/lual/loggers/init.lua
+++ b/lua/lual/loggers/init.lua
@@ -206,17 +206,14 @@ local function create_logging_methods()
         local level_no
         local level_name
 
-        -- Handle both numeric levels and custom level names
+        -- Handle both numeric levels and level names (built-in or custom)
         if type(level_arg) == "number" then
             level_no = level_arg
             level_name = core_levels.get_level_name(level_no)
         elseif type(level_arg) == "string" then
-            -- Check if it's a custom level name
-            local custom_level_value = core_levels.get_custom_level_value(level_arg)
-            if custom_level_value then
-                level_no = custom_level_value
-                level_name = level_arg:upper()
-            else
+            -- Check if it's a valid level name (built-in or custom)
+            level_name, level_no = core_levels.get_level_by_name(level_arg)
+            if not level_name or not level_no then
                 error("Unknown level name: " .. level_arg)
             end
         else
@@ -258,8 +255,8 @@ logger_prototype.__index = function(self, key)
         return logger_prototype[key]
     end
 
-    -- Then check if it's a custom level name
-    local level_name, level_no = core_levels.get_custom_level(key)
+    -- Then check if it's a level name (built-in or custom)
+    local level_name, level_no = core_levels.get_level_by_name(key)
     if level_name and level_no then
         return function(self_inner, ...)
             -- Check if logging is enabled for this level

--- a/spec/custom_levels_spec.lua
+++ b/spec/custom_levels_spec.lua
@@ -191,6 +191,40 @@ describe("Custom Levels", function()
         it("handles unknown levels", function()
             assert.equals("UNKNOWN_LEVEL_NO_99", core_levels.get_level_name(99))
         end)
+
+        it("get_level_by_name resolves both built-in and custom levels", function()
+            -- Test built-in levels
+            local name, value = core_levels.get_level_by_name("debug")
+            assert.equals("DEBUG", name)
+            assert.equals(10, value)
+
+            name, value = core_levels.get_level_by_name("DEBUG")
+            assert.equals("DEBUG", name)
+            assert.equals(10, value)
+
+            name, value = core_levels.get_level_by_name("info")
+            assert.equals("INFO", name)
+            assert.equals(20, value)
+
+            -- Test custom levels
+            name, value = core_levels.get_level_by_name("verbose")
+            assert.equals("VERBOSE", name)
+            assert.equals(25, value)
+
+            name, value = core_levels.get_level_by_name("trace")
+            assert.equals("TRACE", name)
+            assert.equals(15, value)
+
+            -- Test case-insensitivity for custom levels
+            name, value = core_levels.get_level_by_name("VERBOSE")
+            assert.equals("VERBOSE", name)
+            assert.equals(25, value)
+
+            -- Test unknown level
+            name, value = core_levels.get_level_by_name("unknown")
+            assert.is_nil(name)
+            assert.is_nil(value)
+        end)
     end)
 
     describe("get_all_levels()", function()


### PR DESCRIPTION
- Introduced `levels.get_level_by_name` to fetch level information by name, supporting both built-in and custom levels with case insensitivity.
- Updated logger methods to utilize the new function for improved clarity and consistency in handling level names.
- Added tests to verify functionality for both built-in and custom levels, ensuring robustness and correctness.