### PR TITLE
Features/command-line-map

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -13,6 +13,14 @@ Understanding logger trees and propagation.
 - Log event propagation
 - Centralized vs. distributed logging
 
+### **[Command Line Verbosity](command-line-verbosity.md)**
+
+Controlling log levels through command line arguments.
+
+- Default verbosity mappings (`-v`, `-vv`, `-vvv`)
+- Custom flag mappings
+- Integration with CLI applications
+
 ## Learning Path
 
 If you're new to lual, we recommend starting with the [Getting Started](../getting-started/) section first, then reading this guide.

--- a/docs/guide/command-line-verbosity.md
+++ b/docs/guide/command-line-verbosity.md
@@ -1,0 +1,170 @@
+# Command Line Verbosity
+
+Many command-line applications allow users to control verbosity using flags like `-v`, `-vv`, or `--verbose`. lual makes it easy to integrate this pattern into your applications with the command line verbosity feature.
+
+## Basic Usage
+
+The simplest way to enable command line verbosity is:
+
+```lua
+local lual = require("lual")
+
+-- Enable command line verbosity with default settings
+lual.config({
+    command_line_verbosity = { auto_detect = true }
+})
+```
+
+This will automatically detect command line flags and set the root logger's level accordingly.
+
+## Default Mapping
+
+By default, lual recognizes these common flags:
+
+| Flag | Logging Level |
+|------|--------------|
+| `-v` or `--v` | WARNING |
+| `-vv` or `--vv` | INFO |
+| `-vvv` or `--vvv` | DEBUG |
+| `--verbose` | INFO |
+| `--quiet` | ERROR |
+| `--silent` | CRITICAL |
+
+For example:
+
+```bash
+# Run your app with different verbosity levels
+$ lua app.lua                 # Default level (usually WARNING)
+$ lua app.lua -v              # WARNING level 
+$ lua app.lua -vv             # INFO level
+$ lua app.lua -vvv            # DEBUG level
+$ lua app.lua --verbose       # INFO level
+$ lua app.lua --quiet         # ERROR level (shows only errors and critical messages)
+```
+
+## Custom Mapping
+
+You can define your own mapping of command line flags to log levels:
+
+```lua
+lual.config({
+    command_line_verbosity = {
+        mapping = {
+            trace = "debug",       -- Maps --trace flag to DEBUG level
+            standard = "info",     -- Maps --standard flag to INFO level
+            terse = "warning",     -- Maps --terse flag to WARNING level
+            errors = "error",      -- Maps --errors flag to ERROR level
+            critical = "critical"  -- Maps --critical flag to CRITICAL level
+        },
+        auto_detect = true
+    }
+})
+```
+
+Both short flags (e.g., `-trace`) and long flags (e.g., `--trace`) will be recognized.
+
+## Convenience Function
+
+For easier configuration, you can use the `set_command_line_verbosity` function:
+
+```lua
+-- Same as using the command_line_verbosity key in config
+lual.set_command_line_verbosity({
+    mapping = { ... },
+    auto_detect = true
+})
+```
+
+## Disabling Auto-Detection
+
+If you want to configure verbosity mapping but not apply it automatically:
+
+```lua
+lual.config({
+    command_line_verbosity = {
+        mapping = { ... },
+        auto_detect = false
+    }
+})
+
+-- Later, when you're ready to apply:
+local level = lual.get_config().command_line_verbosity.mapping["some_flag"]
+if level then
+    -- Set the level manually
+    lual.config({ level = level })
+end
+```
+
+## Integration with Other Configuration
+
+Command line verbosity works well with other lual configuration options:
+
+```lua
+lual.config({
+    -- Enable command line verbosity
+    command_line_verbosity = { auto_detect = true },
+    
+    -- Configure pipelines (will respect the level set by CLI flags)
+    pipelines = {
+        {
+            outputs = { lual.console },
+            presenter = lual.color()
+        },
+        {
+            outputs = { 
+                { lual.file, path = "app.log" } 
+            },
+            presenter = lual.text()
+        }
+    }
+})
+```
+
+## Complete Example
+
+Here's a complete example showing how to use command line verbosity:
+
+```lua
+local lual = require("lual")
+
+-- Configure with command line verbosity
+lual.config({
+    command_line_verbosity = { auto_detect = true },
+    pipelines = {
+        {
+            -- Level will be set from command line
+            outputs = { lual.console },
+            presenter = lual.color()
+        }
+    }
+})
+
+-- Create logger
+local logger = lual.logger("myapp")
+
+-- Log at different levels
+logger:debug("Detailed debug information")
+logger:info("General information")
+logger:warn("Warning message")
+logger:error("Error condition")
+logger:critical("Critical failure")
+```
+
+## Best Practices
+
+1. **Default to WARNING level** - Let users increase verbosity with flags
+2. **Use auto_detect for CLI applications** - Makes integration easy
+3. **Consider custom mappings for domain-specific applications** - Use terminology familiar to your users
+4. **Document supported flags** - Include in your application's help text
+5. **Use with hierarchical loggers** - Command line verbosity sets the root logger level; child loggers inherit it
+
+## How It Works
+
+The command line verbosity feature:
+
+1. Examines the global `arg` table provided by Lua
+2. Looks for flags in your mapping
+3. Sets the root logger level accordingly
+4. Honors the last matching flag if multiple flags are provided
+
+This makes it easy to integrate logging verbosity control into your command-line applications. 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -41,6 +41,9 @@ Configures the root logger with the specified settings.
 - `pipelines` (table): Array of pipeline configurations.
 - `propagate` (boolean): Whether events propagate (always true for root).
 - `custom_levels` (table): Custom level definitions as name = value pairs.
+- `command_line_verbosity` (table): Configuration for command line argument driven logging level.
+  - `mapping` (table, optional): Custom mapping of command line flags to log level names.
+  - `auto_detect` (boolean, optional): Whether to automatically detect and apply CLI verbosity. Defaults to true.
 
 **Returns:**
 - None
@@ -65,6 +68,23 @@ lual.config({
     pipelines = {
         { outputs = { lual.console }, presenter = lual.text() },
         { outputs = { { lual.file, path = "app.log" } }, presenter = lual.json() }
+    }
+})
+
+-- Configure with command line verbosity detection
+lual.config({
+    pipelines = {
+        { outputs = { lual.console }, presenter = lual.color() }
+    },
+    command_line_verbosity = {
+        mapping = {
+            v = "warning",
+            vv = "info", 
+            vvv = "debug",
+            verbose = "info",
+            quiet = "error"
+        },
+        auto_detect = true
     }
 })
 ```
@@ -523,6 +543,44 @@ Processes a log record through the logging system.
 
 **Returns:**
 - None
+
+### lual.set_command_line_verbosity(verbosity_config)
+
+Sets the command line verbosity configuration for automatic log level detection from command line arguments.
+
+**Parameters:**
+- `verbosity_config` (table): Configuration table for command line verbosity.
+  - `mapping` (table, optional): Custom mapping of command line flags to log level names. Defaults to predefined mappings.
+  - `auto_detect` (boolean, optional): Whether to automatically detect and apply verbosity from command line. Defaults to true.
+
+**Returns:**
+- (table): The updated root logger configuration.
+
+**Examples:**
+```lua
+-- Enable command line verbosity with default mappings
+lual.set_command_line_verbosity({})
+
+-- Custom verbosity mapping
+lual.set_command_line_verbosity({
+    mapping = {
+        v = "warning",
+        vv = "info",
+        vvv = "debug",
+        verbose = "info",
+        quiet = "error"
+    }
+})
+
+-- Configure but disable auto-detection
+lual.set_command_line_verbosity({
+    auto_detect = false
+})
+```
+
+### lual.flush()
+
+Flushes all queued async log events immediately.
 
 ---
 

--- a/lua/lual/api.lua
+++ b/lua/lual/api.lua
@@ -96,6 +96,19 @@ function M.flush()
     async_writer.flush()
 end
 
+-- Sets the command line verbosity configuration
+-- @param verbosity_config table Configuration for command line verbosity mapping
+-- @return table The updated root logger configuration
+function M.set_command_line_verbosity(verbosity_config)
+    if type(verbosity_config) ~= "table" then
+        error("Command line verbosity config must be a table")
+    end
+
+    return config_module.config({
+        command_line_verbosity = verbosity_config
+    })
+end
+
 -- Expose internal functions for testing
 M.create_root_logger = loggers_module.create_root_logger
 

--- a/lua/lual/config/api.lua
+++ b/lua/lual/config/api.lua
@@ -21,6 +21,7 @@ local function register_handlers()
     registry.register("propagate", require("lual.config.propagate"))
     registry.register("pipelines", require("lual.pipelines.config"))
     registry.register("async", require("lual.async.config"))
+    registry.register("command_line_verbosity", require("lual.config.command_line"))
 end
 
 -- Initialize the config system

--- a/lua/lual/config/command_line.lua
+++ b/lua/lual/config/command_line.lua
@@ -1,0 +1,161 @@
+-- Command Line Verbosity Configuration
+-- This module handles command-line driven logging level configuration
+
+-- Note: For direct execution with 'lua', use require("lua.lual.*")
+-- For LuaRocks installed modules or busted tests, use require("lual.*")
+local core_levels = require("lua.lual.levels")
+
+local M = {}
+
+-- Default mapping of command line flags to log levels
+local DEFAULT_MAPPING = {
+    v = "warning",
+    vv = "info",
+    vvv = "debug",
+    verbose = "info",
+    quiet = "error",
+    silent = "critical"
+}
+
+-- Validates command_line_verbosity configuration
+local function validate(config, full_config)
+    if type(config) ~= "table" then
+        return false, "command_line_verbosity must be a table"
+    end
+
+    -- Validate mapping if provided
+    if config.mapping ~= nil then
+        if type(config.mapping) ~= "table" then
+            return false, "command_line_verbosity.mapping must be a table"
+        end
+
+        -- Validate each mapping entry
+        for flag, level_name in pairs(config.mapping) do
+            if type(flag) ~= "string" then
+                return false, "mapping keys must be strings"
+            end
+
+            if type(level_name) ~= "string" then
+                return false, "level names in mapping must be strings"
+            end
+
+            -- Verify level name is valid
+            local level_valid, _ = core_levels.get_level_by_name(level_name:upper())
+            if not level_valid then
+                return false, "unknown level name in mapping: " .. level_name
+            end
+        end
+    end
+
+    -- Validate auto_detect if provided
+    if config.auto_detect ~= nil and type(config.auto_detect) ~= "boolean" then
+        return false, "auto_detect must be a boolean"
+    end
+
+    return true
+end
+
+-- Normalizes command_line_verbosity configuration
+local function normalize(config)
+    local normalized = {}
+
+    -- Use provided mapping or default
+    normalized.mapping = config.mapping or DEFAULT_MAPPING
+
+    -- Default auto_detect to true if not specified
+    if config.auto_detect == nil then
+        normalized.auto_detect = true
+    else
+        normalized.auto_detect = config.auto_detect
+    end
+
+    return normalized
+end
+
+-- Applies command_line_verbosity configuration
+local function apply(config, current_config)
+    current_config.command_line_verbosity = config
+
+    -- If auto_detect is enabled, immediately try to detect and apply CLI verbosity
+    if config.auto_detect then
+        local detected_level = M.detect_verbosity_from_cli(config.mapping)
+        if detected_level then
+            current_config.level = detected_level
+        end
+    end
+
+    return current_config
+end
+
+-- Detects verbosity level from command line arguments
+-- Returns the numeric level if a match is found, nil otherwise
+function M.detect_verbosity_from_cli(mapping)
+    -- Get command line arguments (global arg table)
+    local args = _G.arg
+    if not args or type(args) ~= "table" then
+        return nil
+    end
+
+    local detected_level = nil
+
+    -- Process all command line arguments
+    for _, arg_value in ipairs(args) do
+        -- Check for --flag format
+        if arg_value:sub(1, 2) == "--" then
+            local flag = arg_value:sub(3)
+
+            -- Handle --flag=value format
+            local flag_name, flag_value = flag:match("([^=]+)=(.+)")
+            if flag_name and flag_value then
+                -- Check if flag_value is a valid level name
+                local _, level_value = core_levels.get_level_by_name(flag_value:upper())
+                if level_value then
+                    detected_level = level_value
+                end
+            else
+                -- Check if flag matches a mapping
+                local level_name = mapping[flag]
+                if level_name then
+                    local _, level_value = core_levels.get_level_by_name(level_name:upper())
+                    if level_value then
+                        detected_level = level_value
+                    end
+                end
+            end
+            -- Check for -v, -vv, etc. format
+        elseif arg_value:sub(1, 1) == "-" and arg_value:sub(2, 2) ~= "-" then
+            local flag = arg_value:sub(2)
+
+            -- Check for concatenated flags (e.g., -vvv)
+            if flag:match("^(v+)$") then
+                local level_name = mapping[flag]
+                if level_name then
+                    local _, level_value = core_levels.get_level_by_name(level_name:upper())
+                    if level_value then
+                        detected_level = level_value
+                    end
+                end
+            else
+                -- Check for other single flags
+                local level_name = mapping[flag]
+                if level_name then
+                    local _, level_value = core_levels.get_level_by_name(level_name:upper())
+                    if level_value then
+                        detected_level = level_value
+                    end
+                end
+            end
+        end
+    end
+
+    return detected_level
+end
+
+-- Expose functions
+M.validate = validate
+M.normalize = normalize
+M.apply = apply
+M.detect_verbosity_from_cli = M.detect_verbosity_from_cli
+M.DEFAULT_MAPPING = DEFAULT_MAPPING
+
+return M

--- a/spec/config/command_line_spec.lua
+++ b/spec/config/command_line_spec.lua
@@ -1,0 +1,178 @@
+local command_line = require("lual.config.command_line")
+local lual = require("lual")
+
+describe("Command line verbosity", function()
+    before_each(function()
+        lual.reset_config()
+        _G.arg = {} -- Reset command line arguments
+    end)
+
+    after_each(function()
+        lual.reset_config()
+        _G.arg = {} -- Reset command line arguments
+    end)
+
+    describe("validation", function()
+        it("validates that config is a table", function()
+            local result, msg = command_line.validate("not a table")
+            assert.is_false(result)
+            assert.matches("must be a table", msg)
+        end)
+
+        it("validates that mapping is a table if provided", function()
+            local result, msg = command_line.validate({ mapping = "not a table" })
+            assert.is_false(result)
+            assert.matches("mapping must be a table", msg)
+        end)
+
+        it("validates mapping key types", function()
+            local result, msg = command_line.validate({ mapping = { [123] = "info" } })
+            assert.is_false(result)
+            assert.matches("keys must be strings", msg)
+        end)
+
+        it("validates mapping value types", function()
+            local result, msg = command_line.validate({ mapping = { v = 123 } })
+            assert.is_false(result)
+            assert.matches("level names.*must be strings", msg)
+        end)
+
+        it("validates mapping level names", function()
+            local result, msg = command_line.validate({ mapping = { v = "not_a_level" } })
+            assert.is_false(result)
+            assert.matches("unknown level name", msg)
+        end)
+
+        it("validates auto_detect type", function()
+            local result, msg = command_line.validate({ auto_detect = "not a boolean" })
+            assert.is_false(result)
+            assert.matches("auto_detect must be a boolean", msg)
+        end)
+
+        it("validates a proper config", function()
+            local result = command_line.validate({
+                mapping = { v = "warning", vv = "info", vvv = "debug" },
+                auto_detect = true
+            })
+            assert.is_true(result)
+        end)
+    end)
+
+    describe("normalization", function()
+        it("uses default mapping when not provided", function()
+            local result = command_line.normalize({})
+            assert.is_table(result.mapping)
+            assert.is_same(command_line.DEFAULT_MAPPING, result.mapping)
+        end)
+
+        it("uses custom mapping when provided", function()
+            local custom_mapping = { v = "warning", loud = "critical" }
+            local result = command_line.normalize({ mapping = custom_mapping })
+            assert.is_same(custom_mapping, result.mapping)
+        end)
+
+        it("defaults auto_detect to true", function()
+            local result = command_line.normalize({})
+            assert.is_true(result.auto_detect)
+        end)
+
+        it("preserves auto_detect value when provided", function()
+            local result = command_line.normalize({ auto_detect = false })
+            assert.is_false(result.auto_detect)
+        end)
+    end)
+
+    describe("detection", function()
+        it("handles short flags", function()
+            _G.arg = { "-v" }
+            local level = command_line.detect_verbosity_from_cli(command_line.DEFAULT_MAPPING)
+            assert.equals(lual.warning, level)
+        end)
+
+        it("handles long flags", function()
+            _G.arg = { "--verbose" }
+            local level = command_line.detect_verbosity_from_cli(command_line.DEFAULT_MAPPING)
+            assert.equals(lual.info, level)
+        end)
+
+        it("handles repeated v flags", function()
+            _G.arg = { "-vvv" }
+            local level = command_line.detect_verbosity_from_cli(command_line.DEFAULT_MAPPING)
+            assert.equals(lual.debug, level)
+        end)
+
+        it("handles direct level setting", function()
+            _G.arg = { "--log-level=debug" }
+            local level = command_line.detect_verbosity_from_cli({
+                ["log-level"] = "debug"
+            })
+            assert.equals(lual.debug, level)
+        end)
+
+        it("returns nil when no matching flags found", function()
+            _G.arg = { "--unrelated" }
+            local level = command_line.detect_verbosity_from_cli(command_line.DEFAULT_MAPPING)
+            assert.is_nil(level)
+        end)
+
+        it("uses the last matching flag", function()
+            _G.arg = { "-v", "-vvv" }
+            local level = command_line.detect_verbosity_from_cli(command_line.DEFAULT_MAPPING)
+            assert.equals(lual.debug, level)
+        end)
+    end)
+
+    describe("integration", function()
+        it("changes the root logger level via configuration", function()
+            _G.arg = { "-vvv" } -- Debug level
+
+            -- Initial root level is WARNING
+            assert.equals(lual.warning, lual.get_config().level)
+
+            -- Configure command line verbosity
+            lual.config({
+                command_line_verbosity = { auto_detect = true }
+            })
+
+            -- Level should be changed to DEBUG from command line
+            assert.equals(lual.debug, lual.get_config().level)
+        end)
+
+        it("doesn't apply when auto_detect is false", function()
+            _G.arg = { "-vvv" } -- Debug level
+
+            -- Configure command line verbosity
+            lual.config({
+                command_line_verbosity = { auto_detect = false }
+            })
+
+            -- Level should remain WARNING
+            assert.equals(lual.warning, lual.get_config().level)
+        end)
+
+        it("works with custom mapping", function()
+            _G.arg = { "--trace" } -- Custom flag
+
+            -- Configure command line verbosity with custom mapping
+            lual.config({
+                command_line_verbosity = {
+                    mapping = { trace = "debug" },
+                    auto_detect = true
+                }
+            })
+
+            -- Level should be changed to DEBUG from command line
+            assert.equals(lual.debug, lual.get_config().level)
+        end)
+
+        it("works with convenience function", function()
+            _G.arg = { "-vv" } -- Info level
+
+            -- Use convenience function
+            lual.set_command_line_verbosity({})
+
+            -- Level should be changed to INFO from command line
+            assert.equals(lual.info, lual.get_config().level)
+        end)
+    end)
+end)


### PR DESCRIPTION
- Expanded the README to include a new section on command line verbosity, detailing how to control log levels via command line arguments.
- Updated the API reference to include `command_line_verbosity` configuration options and the new `lual.set_command_line_verbosity` function for setting verbosity based on command line flags.
- Provided examples for configuring command line verbosity, enhancing user guidance and clarity in the documentation.